### PR TITLE
New Close() method, for use when making many New() filemutexs.

### DIFF
--- a/filemutex_test.go
+++ b/filemutex_test.go
@@ -1,11 +1,11 @@
 package filemutex
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,14 +31,26 @@ func TestRLockUnlock(t *testing.T) {
 
 	path := filepath.Join(dir, "x")
 	m, err := New(path)
-	fmt.Println(path)
 	require.NoError(t, err)
 
 	m.RLock()
 	m.RUnlock()
 }
 
-func TestSimultaneousLock(t *testing.T) {
+func TestClose(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "x")
+	m, err := New(path)
+	require.NoError(t, err)
+
+	m.Lock()
+	m.Close()
+}
+
+func TestSequentialLock(t *testing.T) {
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -71,4 +83,110 @@ func TestSimultaneousLock(t *testing.T) {
 
 	<-ch
 	assert.Equal(t, "released", state)
+}
+
+func TestSimultaneousLock(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "x")
+	m, err := New(path)
+	require.NoError(t, err)
+
+	m2, err := New(path)
+	require.NoError(t, err)
+
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	m.Lock()
+
+	state := "waiting"
+	ch := make(chan struct{})
+	go func() {
+		go func() {
+			<-time.After(50 * time.Millisecond)
+			state = "waiting on lock" // for m to unlock before m2 can lock
+			ch <- struct{}{}
+		}()
+		m2.Lock()
+		state = "acquired"
+		ch <- struct{}{}
+
+		<-ch
+		m2.Unlock()
+		state = "closed"
+		ch <- struct{}{}
+	}()
+
+	assert.Equal(t, "waiting", state)
+
+	<-ch
+	assert.Equal(t, "waiting on lock", state)
+
+	m.Unlock()
+
+	<-ch
+	assert.Equal(t, "acquired", state)
+	ch <- struct{}{}
+
+	<-ch
+	assert.Equal(t, "closed", state)
+
+	_, err = os.Stat(path)
+	assert.Nil(t, err)
+}
+
+func TestSimultaneousLockWithClose(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "x")
+	m, err := New(path)
+	require.NoError(t, err)
+
+	m2, err := New(path)
+	require.NoError(t, err)
+
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	m.Lock()
+
+	state := "waiting"
+	ch := make(chan struct{})
+	go func() {
+		go func() {
+			<-time.After(50 * time.Millisecond)
+			state = "waiting on lock" // for m to unlock before m2 can lock
+			ch <- struct{}{}
+		}()
+		m2.Lock()
+		state = "acquired"
+		ch <- struct{}{}
+
+		<-ch
+		m2.Close()
+		state = "closed"
+		ch <- struct{}{}
+	}()
+
+	assert.Equal(t, "waiting", state)
+
+	<-ch
+	assert.Equal(t, "waiting on lock", state)
+
+	m.Close()
+
+	<-ch
+	assert.Equal(t, "acquired", state)
+	ch <- struct{}{}
+
+	<-ch
+	assert.Equal(t, "closed", state)
+
+	_, err = os.Stat(path)
+	assert.NotNil(t, err)
 }

--- a/filemutex_windows.go
+++ b/filemutex_windows.go
@@ -47,8 +47,9 @@ func unlockFileEx(h syscall.Handle, reserved, locklow, lockhigh uint32, ol *sysc
 // FileMutex is similar to sync.RWMutex, but also synchronizes across processes.
 // This implementation is based on flock syscall.
 type FileMutex struct {
-	mu sync.RWMutex
-	fd syscall.Handle
+	mu   sync.RWMutex
+	fd   syscall.Handle
+	path string
 }
 
 func New(filename string) (*FileMutex, error) {
@@ -57,7 +58,7 @@ func New(filename string) (*FileMutex, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &FileMutex{fd: fd}, nil
+	return &FileMutex{fd: fd, path: filename}, nil
 }
 
 func (m *FileMutex) Lock() {
@@ -90,4 +91,17 @@ func (m *FileMutex) RUnlock() {
 		panic(err)
 	}
 	m.mu.RUnlock()
+}
+
+// Close does an Unlock() combined with closing and unlinking the associated
+// lock file. You should create a New() FileMutex for every Lock() attempt if
+// using Close().
+func (m *FileMutex) Close() {
+	var ol syscall.Overlapped
+	if err := unlockFileEx(m.fd, 0, 1, 0, &ol); err != nil {
+		panic(err)
+	}
+	syscall.Close(m.fd)
+	syscall.Unlink(m.path)
+	m.mu.Unlock()
 }


### PR DESCRIPTION
Added test for real simultaneous lock attempt.
Removed debug Printf from test script.

The motivation for the new Close() method is that I create many different filemutex lock files and with normal Unlock() eventually hit the error:

> too many open files

So Close() is needed to clean up the file descriptors.

The original `TestSimultaneousLock` test was not actually testing simultaneous behaviour. Rather, what happened was a Lock() followed by an Unlock(), followed by a Lock() and Unlock(). Which is sequential, and didn't prove that you can't have 2 locks held open simultaneously.