### PR TITLE
Return errors

### DIFF
--- a/filemutex_flock.go
+++ b/filemutex_flock.go
@@ -30,30 +30,36 @@ func New(filename string) (*FileMutex, error) {
 	return &FileMutex{fd: fd}, nil
 }
 
-func (m *FileMutex) Lock() {
+func (m *FileMutex) Lock() error {
 	m.mu.Lock()
 	if err := syscall.Flock(m.fd, syscall.LOCK_EX); err != nil {
-		panic(err)
+		m.mu.Unlock()
+		return err
 	}
+	return nil
 }
 
-func (m *FileMutex) Unlock() {
+func (m *FileMutex) Unlock() error {
 	if err := syscall.Flock(m.fd, syscall.LOCK_UN); err != nil {
-		panic(err)
+		return err
 	}
 	m.mu.Unlock()
+	return nil
 }
 
-func (m *FileMutex) RLock() {
+func (m *FileMutex) RLock() error {
 	m.mu.RLock()
 	if err := syscall.Flock(m.fd, syscall.LOCK_SH); err != nil {
-		panic(err)
+		m.mu.RUnlock()
+		return err
 	}
+	return nil
 }
 
-func (m *FileMutex) RUnlock() {
+func (m *FileMutex) RUnlock() error {
 	if err := syscall.Flock(m.fd, syscall.LOCK_UN); err != nil {
-		panic(err)
+		return err
 	}
 	m.mu.RUnlock()
+	return nil
 }

--- a/filemutex_test.go
+++ b/filemutex_test.go
@@ -1,7 +1,6 @@
 package filemutex
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -33,7 +32,6 @@ func TestRLockUnlock(t *testing.T) {
 
 	path := filepath.Join(dir, "x")
 	m, err := New(path)
-	fmt.Println(path)
 	require.NoError(t, err)
 
 	err = m.RLock()

--- a/filemutex_test.go
+++ b/filemutex_test.go
@@ -20,8 +20,10 @@ func TestLockUnlock(t *testing.T) {
 	m, err := New(path)
 	require.NoError(t, err)
 
-	m.Lock()
-	m.Unlock()
+	err = m.Lock()
+	require.NoError(t, err)
+	err = m.Unlock()
+	require.NoError(t, err)
 }
 
 func TestRLockUnlock(t *testing.T) {
@@ -34,8 +36,10 @@ func TestRLockUnlock(t *testing.T) {
 	fmt.Println(path)
 	require.NoError(t, err)
 
-	m.RLock()
-	m.RUnlock()
+	err = m.RLock()
+	require.NoError(t, err)
+	err = m.RUnlock()
+	require.NoError(t, err)
 }
 
 func TestSimultaneousLock(t *testing.T) {
@@ -47,23 +51,27 @@ func TestSimultaneousLock(t *testing.T) {
 	m, err := New(path)
 	require.NoError(t, err)
 
-	m.Lock()
+	err = m.Lock()
+	require.NoError(t, err)
 
 	state := "waiting"
 	ch := make(chan struct{})
 	go func() {
-		m.Lock()
+		err = m.Lock()
+		require.NoError(t, err)
 		state = "acquired"
 		ch <- struct{}{}
 
 		<-ch
-		m.Unlock()
+		err = m.Unlock()
+		require.NoError(t, err)
 		state = "released"
 		ch <- struct{}{}
 	}()
 
 	assert.Equal(t, "waiting", state)
-	m.Unlock()
+	err = m.Unlock()
+	require.NoError(t, err)
 
 	<-ch
 	assert.Equal(t, "acquired", state)
@@ -71,4 +79,118 @@ func TestSimultaneousLock(t *testing.T) {
 
 	<-ch
 	assert.Equal(t, "released", state)
+}
+
+func TestLockErrorsAreRecoverable(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "x")
+	m, err := New(path)
+	require.NoError(t, err)
+
+	// muck with the internal state in order to cause an error
+	oldfd := m.fd
+	m.fd = 99999
+
+	// trigger an error
+	err = m.Lock()
+	require.Error(t, err)
+
+	// restore a sane internal state
+	m.fd = oldfd
+
+	// this would hang if we hadn't Unlock()ed in the Lock error branch
+	err = m.Lock()
+	require.NoError(t, err)
+
+	// clean up
+	err = m.Unlock()
+	require.NoError(t, err)
+}
+
+func TestUnlockErrorsAreRecoverable(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "x")
+	m, err := New(path)
+	require.NoError(t, err)
+
+	err = m.Lock()
+	require.NoError(t, err)
+
+	// muck with the internal state in order to cause an error
+	oldfd := m.fd
+	m.fd = 99999
+
+	// trigger an error
+	err = m.Unlock()
+	require.Error(t, err)
+
+	// restore a sane internal state
+	m.fd = oldfd
+
+	// this would crash if we the mutex were unlocked in the error branch
+	err = m.Unlock()
+	require.NoError(t, err)
+}
+
+func TestRLockErrorsAreRecoverable(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "x")
+	m, err := New(path)
+	require.NoError(t, err)
+
+	// muck with the internal state in order to cause an error
+	oldfd := m.fd
+	m.fd = 99999
+
+	// trigger an error
+	err = m.RLock()
+	require.Error(t, err)
+
+	// restore a sane internal state
+	m.fd = oldfd
+
+	// this would hang if we hadn't Unlock()ed in the RLock error branch
+	err = m.Lock()
+	require.NoError(t, err)
+
+	// clean up
+	err = m.Unlock()
+	require.NoError(t, err)
+}
+
+func TestRUnlockErrorsAreRecoverable(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "x")
+	m, err := New(path)
+	require.NoError(t, err)
+
+	err = m.RLock()
+	require.NoError(t, err)
+
+	// muck with the internal state in order to cause an error
+	oldfd := m.fd
+	m.fd = 99999
+
+	// trigger an error
+	err = m.RUnlock()
+	require.Error(t, err)
+
+	// restore a sane internal state
+	m.fd = oldfd
+
+	// this would crash if we the mutex were unlocked in the error branch
+	err = m.RUnlock()
+	require.NoError(t, err)
 }

--- a/filemutex_windows.go
+++ b/filemutex_windows.go
@@ -60,34 +60,40 @@ func New(filename string) (*FileMutex, error) {
 	return &FileMutex{fd: fd}, nil
 }
 
-func (m *FileMutex) Lock() {
+func (m *FileMutex) Lock() error {
 	m.mu.Lock()
 	var ol syscall.Overlapped
 	if err := lockFileEx(m.fd, lockfileExclusiveLock, 0, 1, 0, &ol); err != nil {
-		panic(err)
+		m.mu.Unlock()
+		return err
 	}
+	return nil
 }
 
-func (m *FileMutex) Unlock() {
+func (m *FileMutex) Unlock() error {
 	var ol syscall.Overlapped
 	if err := unlockFileEx(m.fd, 0, 1, 0, &ol); err != nil {
-		panic(err)
+		return err
 	}
 	m.mu.Unlock()
+	return nil
 }
 
-func (m *FileMutex) RLock() {
+func (m *FileMutex) RLock() error {
 	m.mu.RLock()
 	var ol syscall.Overlapped
 	if err := lockFileEx(m.fd, 0, 0, 1, 0, &ol); err != nil {
-		panic(err)
+		m.mu.RUnlock()
+		return err
 	}
+	return nil
 }
 
-func (m *FileMutex) RUnlock() {
+func (m *FileMutex) RUnlock() error {
 	var ol syscall.Overlapped
 	if err := unlockFileEx(m.fd, 0, 1, 0, &ol); err != nil {
-		panic(err)
+		return err
 	}
 	m.mu.RUnlock()
+	return nil
 }


### PR DESCRIPTION
Fixes #3 

Caveat: I don't have access to a Windows box.

```
GOOS=windows go test -c
```
works, but  I don't know the tests actually pass.