### PR TITLE
Add method to close file handle

### DIFF
--- a/filemutex_flock.go
+++ b/filemutex_flock.go
@@ -30,6 +30,10 @@ func New(filename string) (*FileMutex, error) {
 	return &FileMutex{fd: fd}, nil
 }
 
+func (m *FileMutex) Close() error {
+	return syscall.Close(m.fd)
+}
+
 func (m *FileMutex) Lock() error {
 	m.mu.Lock()
 	if err := syscall.Flock(m.fd, syscall.LOCK_EX); err != nil {

--- a/filemutex_test.go
+++ b/filemutex_test.go
@@ -23,6 +23,9 @@ func TestLockUnlock(t *testing.T) {
 	require.NoError(t, err)
 	err = m.Unlock()
 	require.NoError(t, err)
+
+	err = m.Close()
+	require.NoError(t, err)
 }
 
 func TestRLockUnlock(t *testing.T) {

--- a/filemutex_windows.go
+++ b/filemutex_windows.go
@@ -60,6 +60,10 @@ func New(filename string) (*FileMutex, error) {
 	return &FileMutex{fd: fd}, nil
 }
 
+func (m *FileMutex) Close() error {
+	return syscall.CloseHandle(m.fd)
+}
+
 func (m *FileMutex) Lock() error {
 	m.mu.Lock()
 	var ol syscall.Overlapped


### PR DESCRIPTION
This PR proposes adding a Close method to close the underlying handle as its a good practice to do so. Have added a call in the LockUnlock test and have tested on Linux and Windows.

We're using this library for cross-platform file-locking in a CNI Plugin (see containernetworking/plugins#77) and this will allow the store close method to actually close.