### PR TITLE
Add appveyor for CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+clone_folder: c:\gopath\src\github.com\alexflint\go-filemutex
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - echo %PATH%
+  - echo %GOPATH%
+  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
+  - go version
+  - go env
+
+build: off
+
+test_script:
+  - go get -t ./...
+  - go test -v ./...


### PR DESCRIPTION
Windows CI!

Requires AppVeyor integration to be enabled for this project on GitHub.

[Sample build output](https://ci.appveyor.com/project/rosenhouse/go-filemutex)