### PR TITLE
Add travis file for linux CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+install:
+ - go get -t ./...
+
+script:
+ - go test -v ./...


### PR DESCRIPTION
Linux CI

Requires Travis CI integration on GitHub

[Sample build output here](https://travis-ci.org/rosenhouse/go-filemutex)