### PR TITLE
Non blocking lock

### DIFF
--- a/filemutex.go
+++ b/filemutex.go
@@ -1,0 +1,5 @@
+package filemutex
+
+import "errors"
+
+var AlreadyLocked = errors.New("lock already acquired")

--- a/filemutex_flock.go
+++ b/filemutex_flock.go
@@ -35,8 +35,15 @@ func (m *FileMutex) Lock() error {
 	return nil
 }
 
+var AlreadyLocked = errors.New("lock already acquired")
+
 func (m *FileMutex) TryLock() error {
 	if err := syscall.Flock(m.fd, syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errno, ok := err.(syscall.Errno); ok {
+			if errno == syscall.EWOULDBLOCK {
+				return AlreadyLocked
+			}
+		}
 		return err
 	}
 	return nil

--- a/filemutex_flock.go
+++ b/filemutex_flock.go
@@ -35,8 +35,6 @@ func (m *FileMutex) Lock() error {
 	return nil
 }
 
-var AlreadyLocked = errors.New("lock already acquired")
-
 func (m *FileMutex) TryLock() error {
 	if err := syscall.Flock(m.fd, syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		if errno, ok := err.(syscall.Errno); ok {

--- a/filemutex_flock.go
+++ b/filemutex_flock.go
@@ -35,6 +35,13 @@ func (m *FileMutex) Lock() error {
 	return nil
 }
 
+func (m *FileMutex) TryLock() error {
+	if err := syscall.Flock(m.fd, syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *FileMutex) Unlock() error {
 	if err := syscall.Flock(m.fd, syscall.LOCK_UN); err != nil {
 		return err

--- a/filemutex_test.go
+++ b/filemutex_test.go
@@ -24,6 +24,27 @@ func TestLockUnlock(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestTryLockUnlock(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "x")
+	m, err := New(path)
+	require.NoError(t, err)
+	m2, err := New(path)
+	require.NoError(t, err)
+
+	err = m.Lock()
+	require.NoError(t, err)
+	err = m2.TryLock()
+	require.Error(t, err)
+	err = m.Unlock()
+	require.NoError(t, err)
+	err = m2.TryLock()
+	require.NoError(t, err)
+}
+
 func TestRLockUnlock(t *testing.T) {
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)

--- a/filemutex_test.go
+++ b/filemutex_test.go
@@ -38,7 +38,7 @@ func TestTryLockUnlock(t *testing.T) {
 	err = m.Lock()
 	require.NoError(t, err)
 	err = m2.TryLock()
-	require.Error(t, err)
+	require.Equal(t, AlreadyLocked, err)
 	err = m.Unlock()
 	require.NoError(t, err)
 	err = m2.TryLock()


### PR DESCRIPTION
using `LOCK_NB` flag together with `LOCK_EX` gives a non-blocking `Lock`, returning an error if the Mutex is already locked.